### PR TITLE
feat: add critical branch safety checks to /implement skill

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -23,6 +23,15 @@ You are a senior engineer executing a single, well-scoped task in this repositor
 
 ## Workflow (Must Follow)
 
+**🚨 CRITICAL SAFETY RULE - READ FIRST:**
+
+**NEVER commit or push to the default branch (main/master)**
+
+- All work MUST be done on a feature branch
+- Always verify current branch before: committing, pushing, or creating PR
+- The helper script includes safety checks to prevent accidental pushes to default branch
+- If you're ever on the default branch, immediately switch to your feature branch
+
 ### 1. Understand & Validate
 
 - Understand the task objective and constraints
@@ -49,6 +58,13 @@ git pull origin $DEFAULT_BRANCH
 # Create new feature branch from updated default branch
 git checkout -b <branch-name>
 ```
+
+**⚠️ CRITICAL SAFETY RULE:**
+
+- **NEVER push to the default branch (main/master)**
+- **ONLY push to your newly created feature branch**
+- Always verify you're on the correct branch before pushing: `git branch --show-current`
+- If you accidentally switch to default branch, immediately switch back to your feature branch
 
 **Branch naming convention:**
 
@@ -97,7 +113,23 @@ pnpm -s test
 
 ### 5. Commit Discipline
 
-Use **Conventional Commits** (commitlint enforced):
+**⚠️ BEFORE COMMITTING - Verify you're on your feature branch:**
+
+```bash
+# Check current branch
+CURRENT_BRANCH=$(git branch --show-current)
+DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+
+# Safety check
+if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+    echo "❌ ERROR: You are on $DEFAULT_BRANCH - switch to your feature branch!"
+    exit 1
+fi
+
+echo "✓ Safe to commit on branch: $CURRENT_BRANCH"
+```
+
+**Use Conventional Commits** (commitlint enforced):
 
 ```
 feat: add user avatar upload to profile settings
@@ -107,6 +139,8 @@ chore: update dependencies to latest versions
 
 **Rules:**
 
+- **NEVER commit directly to default branch (main/master)**
+- Always verify current branch before committing
 - Make commits logically grouped
 - Avoid generic messages like "misc" or "updates"
 - Use imperative mood: "add feature" not "added feature"
@@ -136,7 +170,22 @@ chore: update dependencies to latest versions
    gh auth status || gh auth login
    ```
 
-2. **Update branch with latest changes from default branch:**
+2. **Verify you're on your feature branch (CRITICAL SAFETY CHECK):**
+
+   ```bash
+   CURRENT_BRANCH=$(git branch --show-current)
+   DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+
+   if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+       echo "❌ ERROR: You are on $DEFAULT_BRANCH - DO NOT PUSH!"
+       echo "Switch to your feature branch first"
+       exit 1
+   fi
+
+   echo "✓ Safe to proceed on branch: $CURRENT_BRANCH"
+   ```
+
+3. **Update branch with latest changes from default branch:**
 
    ```bash
    # Get default branch name
@@ -153,7 +202,7 @@ chore: update dependencies to latest versions
    # git rebase --continue
    ```
 
-3. **Push branch and create PR:**
+4. **Push branch and create PR:**
 
    **Option A: Use the helper script** (recommended):
 
@@ -353,6 +402,8 @@ export async function myServerAction(input: unknown) {
 
 ❌ **DO NOT**:
 
+- **🚨 CRITICAL: NEVER commit or push to default branch (main/master)** - Always work on feature branches
+- **🚨 CRITICAL: NEVER skip branch verification before pushing** - Always check `git branch --show-current`
 - Skip tests ("I'll add tests later")
 - Commit without running quality gates locally first
 - Add dependencies without asking
@@ -369,6 +420,8 @@ export async function myServerAction(input: unknown) {
 
 ✅ **DO**:
 
+- **Always verify you're on a feature branch before committing/pushing**
+- Use the helper script's built-in safety checks
 - Run all quality gates before committing
 - Keep PRs focused and small
 - Ask before adding dependencies

--- a/.claude/skills/implement/create-pr.sh
+++ b/.claude/skills/implement/create-pr.sh
@@ -24,6 +24,17 @@ echo "Getting default branch name..."
 DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
 echo "Default branch: $DEFAULT_BRANCH"
 
+# SAFETY CHECK: Never push to default branch
+if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+    echo "❌ ERROR: Cannot push to default branch '$DEFAULT_BRANCH'"
+    echo "You are currently on the default branch."
+    echo "Please switch to your feature branch first:"
+    echo "  git checkout <your-feature-branch>"
+    exit 1
+fi
+
+echo "✓ Current branch: $BRANCH (safe to push)"
+
 # Get arguments
 PR_TITLE="${1:-feat: update}"
 WHAT_WHY="${2:-[Brief description of what changed and why]}"


### PR DESCRIPTION
Added comprehensive safety mechanisms to prevent accidental commits/pushes to default branch:

**New Safety Features:**

1. **Prominent Warning at Top of Workflow**
   - 🚨 CRITICAL SAFETY RULE section added at workflow start
   - Clear instructions: NEVER commit or push to default branch
   - Emphasizes all work MUST be on feature branches

2. **Branch Verification Before Commits (Step 5)**
   - Added safety check script before committing
   - Verifies current branch != default branch
   - Exits with error if on default branch
   - Shows confirmation when on safe branch

3. **Branch Verification Before PR (Step 6)**
   - New step 2: Verify you're on feature branch
   - Blocks PR creation if on default branch
   - Clear error messages with remediation steps

4. **Helper Script Safety (.claude/skills/implement/create-pr.sh)**
   - Auto-detects default branch name
   - Compares current branch against default
   - Exits with error if attempting to push to default
   - Shows clear error message and instructions

5. **Updated Anti-Patterns Section**
   - Added as first two items (marked CRITICAL)
   - Never commit/push to default branch
   - Never skip branch verification

**Safety Check Logic:**
```bash
CURRENT_BRANCH=$(git branch --show-current)
DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)

if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
    echo "❌ ERROR: You are on $DEFAULT_BRANCH - DO NOT PUSH!"
    exit 1
fi
```

Benefits:
- Prevents accidental commits to protected branches
- Multiple layers of safety checks
- Clear error messages guide correct behavior
- Helper script enforces safety automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)